### PR TITLE
複数代入文の内部変数番号ミス修正と、宣言の追加

### DIFF
--- a/src/nako_gen.mjs
+++ b/src/nako_gen.mjs
@@ -1533,9 +1533,9 @@ export class NakoGen {
         let code = '';
         const vtype = node.vartype; // 変数 or 定数
         const value = (node.value === null) ? 'null' : this._convGen(node.value, true);
-        this.loopId++;
-        const varI = `$nako_i${this.loopId}`;
-        code += `${varI}=${value}\n`;
+        const id = this.loopId++;
+        const varI = `$nako_i${id}`;
+        code += `const ${varI}=${value}\n`;
         code += `if (!(${varI} instanceof Array)) { ${varI}=[${varI}] }\n`;
         const names = (node.names) ? node.names : [];
         for (let i = 0; i < names.length; i++) {

--- a/src/nako_gen.mts
+++ b/src/nako_gen.mts
@@ -1591,9 +1591,9 @@ export class NakoGen {
     let code = ''
     const vtype = node.vartype // 変数 or 定数
     const value = (node.value === null) ? 'null' : this._convGen(node.value, true)
-    this.loopId++
-    const varI = `$nako_i${this.loopId}`
-    code += `${varI}=${value}\n`
+    const id = this.loopId++
+    const varI = `$nako_i${id}`
+    code += `const ${varI}=${value}\n`
     code += `if (!(${varI} instanceof Array)) { ${varI}=[${varI}] }\n`
     const names: Ast[] = (node.names) ? node.names : []
     for (let i = 0; i < names.length; i++) {


### PR DESCRIPTION
```
A,B,C = [1,2,3]。Bを表示
```
の様な複数代入文を使用したとき、
`cnako3 -c main.nako3 && node main.mjs` とコンパイルして実行したとき、生成コードに宣言が抜けていたためエラーになっていた問題を修正。

また、他の場所はインクリメント前の loopId を使用しているが、この箇所はインクリメント後の loopId を使用しているため、内部変数名が衝突してしまっていたので、修正。