### PR TITLE
undefinedチェックの警告メッセージが正しく表示されるよう修正

### DIFF
--- a/src/plugin_system.mts
+++ b/src/plugin_system.mts
@@ -125,7 +125,7 @@ export default {
       sys.chk = (value:any, constId: number): any => {
         if (typeof value === 'undefined') {
           const cp = sys.constPools[constId]
-          const { msgNo, msgArgs, fileNo, lineNo } = cp
+          const [ msgNo, msgArgs, fileNo, lineNo ] = cp
           let msg = sys.constPoolsTemplate[msgNo]
           for (const i in msgArgs) {
             const arg = sys.constPoolsTemplate[msgArgs[i]]


### PR DESCRIPTION
文字列定数テンプレートから参照の際に{}と[]の誤りと思われる
部分があるため、表示内容の取り出しに失敗してundefinedになっている。

以下、表示内容中の不要部分は削除。
修正前では警告メッセージは以下となる

> D:\git\nadesiko3core>node command/snako.mjs -- -d -e "HOGEを表示。"
> [警告]main.nako3(1行目): 変数『HOGE』は定義されていません。
> [警告]undefined
> undefined
> undefined

本修正で以下となる。

> D:\git\nadesiko3core>node command/snako.mjs -- -d -e "HOGEを表示。"
> [警告]main.nako3(1行目): 変数『HOGE』は定義されていません。
> [警告]main.nako3(1行目): 命令『表示』の引数にundefinedを渡しています。
> undefined
> undefined

※修正前でundefinedが３つ、修正後でも２つはのは未確認。