### PR TITLE
ユーザ定義関数の関数オブジェクトを返す前置詞{関数}を追加。

### DIFF
--- a/src/nako_parser3.mts
+++ b/src/nako_parser3.mts
@@ -1967,6 +1967,9 @@ export class NakoParser extends NakoParserBase {
     // 変数
     const word = this.yValueWord()
     if (word) { return word }
+    // 関数への参照
+    const func_pointer = this.yValueFuncPointer()
+    if (func_pointer) { return func_pointer }
     // その他
     return null
   }
@@ -2028,6 +2031,23 @@ export class NakoParser extends NakoParserBase {
       }
     }
     return false
+  }
+
+  /** @returns {Ast | null} */
+  yValueFuncPointer (): Ast|null {
+    const map = this.peekSourceMap()
+    if (this.check('func_pointer')) {
+      const t = this.getCur()
+      const ast:Ast = {
+        type: 'func_pointer',
+        name: t.value,
+        josi: t.josi,
+        ...map,
+        end: this.peekSourceMap()
+      }
+      return ast
+    }
+    return null
   }
 
   /** @returns {Ast | null} */


### PR DESCRIPTION
もともとの以下が
`Bとは変数=「HOGE処理」のJSオブジェクト取得`
以下ともかけるようになります。
`Bとは変数={関数}HOGE処理`

実装の目的として、ソース上の識別子(ユーザ関数名)を文字列データとして
扱う必要性を抑えるためです。高度なエディタを用いた場合の
ハイライトや一括Renameを少し想定しています。
実行時にネームスペース名の検索が行われるのを避ける効果もあります。
（文字列内で無ければトランスパイルの際にネームスペースが検索・追加される）