### PR TITLE
繰り返す構文で増か減の指定(無/増/減)をASTで判るよう修正

### DIFF
--- a/src/nako_parser3.mts
+++ b/src/nako_parser3.mts
@@ -846,6 +846,7 @@ export class NakoParser extends NakoParserBase {
   /** @returns {Ast | null} */
   yFor (): Ast|null {
     let flagDown = true // AからBまでの時、A>=Bを許容するかどうか
+    let loopDirection : null | 'up' | 'down' = null // ループの方向を一方向に限定する
     const map = this.peekSourceMap()
     if (this.check('繰返') || this.check('増繰返') || this.check('減繰返')) {
       // pass
@@ -868,6 +869,7 @@ export class NakoParser extends NakoParserBase {
     if (kurikaesu.type === '増繰返' || kurikaesu.type === '減繰返') {
       vInc = this.popStack(['ずつ'])
       if (kurikaesu.type === '増繰返') { flagDown = false }
+      loopDirection = kurikaesu.type === '増繰返' ? 'up' : 'down'
     }
     const vTo = this.popStack(['まで'])
     const vFrom = this.popStack(['から'])
@@ -900,6 +902,7 @@ export class NakoParser extends NakoParserBase {
       to: vTo,
       inc: vInc,
       flagDown,
+      loopDirection,
       word,
       block: block || [],
       josi: '',

--- a/src/nako_types.mts
+++ b/src/nako_types.mts
@@ -93,6 +93,7 @@ export interface Ast {
     inc?: Ast[] | Ast | null | string; // for
     word?: Ast | Token | null; // for
     flagDown?: boolean; // for
+    loopDirection?: null | 'up' | 'down'; // for
     name?: Token | Ast | null | string;
     names?: Ast[];
     args?: Ast[]; // 関数の引数


### PR DESCRIPTION
generatorの実装者が双方向を考慮したロジックにしない選択ができるように。
ASTは変わるものの、ｎadesiko3core/nadesiko3自体の動作に変化はありません。

手元のnako_gen_simpleというものを作成していて、そこではloopDirectionに従い、
・nullならば、従来と同じで双方向。実行時のfromとtoの大小で切り替わる。
・upならば、from<toと仮定してto以上になるまでループする。
・downならば、from>toと仮定してto以下になるまでループする。
s
stepに負数を指定すると１度も実行されないか無限ループかのいずれかです。
(その分、生成コードのサイズとソースにない命令・機能が変換後に含まれるの避ける)